### PR TITLE
separated out riot API calls to lib file, added interfaces for responses

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,10 +5,16 @@ export default {
   clearMocks: true,
   setupFiles: ["<rootDir>/jest.setup.js"],
   transform: {
-    '^.+\\.ts$': ['ts-jest', {
-      tsconfig: {
-        types: ['jest', '@types/jest']
-      }
-    }]
-  }
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        tsconfig: {
+          types: ["jest", "@types/jest"],
+        },
+      },
+    ],
+  },
+  moduleNameMapper: {
+    "^~/(.*)$": "<rootDir>/src/$1",
+  },
 };

--- a/src/app/api/riot/route.test.ts
+++ b/src/app/api/riot/route.test.ts
@@ -1,35 +1,29 @@
 import { GET } from "./route";
 import { NextRequest } from "next/server";
 
-// Type definitions for API responses
-interface ErrorResponse {
-  error: string;
-}
+import type {
+  RiotAccountResponse,
+  RiotMatchHistoryResponse,
+  RiotMatchInfoResponse,
+  RiotMatchTimelineResponse,
+} from "~/types/riot";
 
-interface AccountResponse {
-  puuid: string;
-  gameName: string;
-  tagLine: string;
-}
-
-interface MatchHistoryResponse {
-  matchIds: string[];
-}
-
-interface MatchInfoResponse {
-  metadata: Record<string, unknown>;
-}
+import type { ErrorResponse } from "~/types/error";
 
 // Mock fetch globally
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
+
 describe("GET default case", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it("returns 400 if invalid action", async () => {
     const url = new URL("http://localhost/api/riot?action=badaction");
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = await response.json() as ErrorResponse;
+    const json = (await response.json()) as ErrorResponse;
 
     expect(response.status).toBe(400);
     expect(json.error).toBe(
@@ -38,6 +32,9 @@ describe("GET default case", () => {
   });
 });
 describe("GET account", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it("returns 400 if tagLine is excluded", async () => {
     const url = new URL(
       "http://localhost/api/riot?action=account&gameName=test",
@@ -45,7 +42,7 @@ describe("GET account", () => {
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = await response.json() as ErrorResponse;
+    const json = (await response.json()) as ErrorResponse;
 
     expect(response.status).toBe(400);
     expect(json.error).toBe(
@@ -59,7 +56,7 @@ describe("GET account", () => {
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = await response.json() as ErrorResponse;
+    const json = (await response.json()) as ErrorResponse;
 
     expect(response.status).toBe(400);
     expect(json.error).toBe(
@@ -67,7 +64,7 @@ describe("GET account", () => {
     );
   });
   it("returns 200 with account details if valid gameName and tagLine are set", async () => {
-    const mockResponse: AccountResponse = {
+    const mockResponse: RiotAccountResponse = {
       puuid: "12345",
       gameName: "TestUser",
       tagLine: "testTag",
@@ -78,9 +75,9 @@ describe("GET account", () => {
       headers: new Headers(),
       redirected: false,
       status: 200,
-      statusText: 'OK',
-      type: 'basic',
-      url: '',
+      statusText: "OK",
+      type: "basic",
+      url: "",
       clone: jest.fn(),
       body: null,
       bodyUsed: false,
@@ -96,7 +93,7 @@ describe("GET account", () => {
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = await response.json() as AccountResponse;
+    const json = (await response.json()) as RiotAccountResponse;
 
     expect(response.status).toBe(200);
     expect(json).toEqual(mockResponse);
@@ -115,9 +112,9 @@ describe("GET account", () => {
       headers: new Headers(),
       redirected: false,
       status: 404,
-      statusText: 'Not Found',
-      type: 'basic',
-      url: '',
+      statusText: "Not Found",
+      type: "basic",
+      url: "",
       clone: jest.fn(),
       body: null,
       bodyUsed: false,
@@ -133,7 +130,7 @@ describe("GET account", () => {
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = await response.json() as ErrorResponse;
+    const json = (await response.json()) as ErrorResponse;
 
     expect(response.status).toBe(500);
     expect(json.error).toEqual("Failed to fetch account data");
@@ -141,28 +138,31 @@ describe("GET account", () => {
 });
 
 describe("GET match-history", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it("returns 400 if puuid is excluded", async () => {
     const url = new URL("http://localhost/api/riot?action=match-history");
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = await response.json() as ErrorResponse;
+    const json = (await response.json()) as ErrorResponse;
 
     expect(response.status).toBe(400);
     expect(json.error).toBe("puuid is required for match history lookup");
   });
   it("returns 200 with match history if valid puuid", async () => {
     const matches = ["NA_testmatch1", "NA_testmatch2"];
-    const mockResponse: MatchHistoryResponse = { matchIds: matches };
+    const mockResponse: RiotMatchHistoryResponse = matches;
     (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
       ok: true,
       json: async () => matches,
       headers: new Headers(),
       redirected: false,
       status: 200,
-      statusText: 'OK',
-      type: 'basic',
-      url: '',
+      statusText: "OK",
+      type: "basic",
+      url: "",
       clone: jest.fn(),
       body: null,
       bodyUsed: false,
@@ -178,7 +178,7 @@ describe("GET match-history", () => {
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = await response.json() as MatchHistoryResponse;
+    const json = (await response.json()) as RiotMatchHistoryResponse;
 
     expect(response.status).toBe(200);
     expect(json).toEqual(mockResponse);
@@ -196,9 +196,9 @@ describe("GET match-history", () => {
       headers: new Headers(),
       redirected: false,
       status: 404,
-      statusText: 'Not Found',
-      type: 'basic',
-      url: '',
+      statusText: "Not Found",
+      type: "basic",
+      url: "",
       clone: jest.fn(),
       body: null,
       bodyUsed: false,
@@ -214,7 +214,7 @@ describe("GET match-history", () => {
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = await response.json() as ErrorResponse;
+    const json = (await response.json()) as ErrorResponse;
 
     expect(response.status).toBe(500);
     expect(json.error).toEqual("Failed to fetch match history");
@@ -222,27 +222,30 @@ describe("GET match-history", () => {
 });
 
 describe("GET match-info", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it("returns 400 if matchId is excluded", async () => {
     const url = new URL("http://localhost/api/riot?action=match-info");
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = await response.json() as ErrorResponse;
+    const json = (await response.json()) as ErrorResponse;
 
     expect(response.status).toBe(400);
     expect(json.error).toBe("matchId is required for match info lookup");
   });
   it("returns 200 with match info if valid match id", async () => {
-    const mockResponse: MatchInfoResponse = { metadata: {} };
+    const mockResponse: RiotMatchInfoResponse = { metadata: {}, info: {} };
     (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
       ok: true,
       json: async () => mockResponse,
       headers: new Headers(),
       redirected: false,
       status: 200,
-      statusText: 'OK',
-      type: 'basic',
-      url: '',
+      statusText: "OK",
+      type: "basic",
+      url: "",
       clone: jest.fn(),
       body: null,
       bodyUsed: false,
@@ -258,7 +261,7 @@ describe("GET match-info", () => {
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = await response.json() as MatchInfoResponse;
+    const json = (await response.json()) as RiotMatchInfoResponse;
 
     expect(response.status).toBe(200);
     expect(json).toEqual(mockResponse);
@@ -275,9 +278,9 @@ describe("GET match-info", () => {
       headers: new Headers(),
       redirected: false,
       status: 404,
-      statusText: 'Not Found',
-      type: 'basic',
-      url: '',
+      statusText: "Not Found",
+      type: "basic",
+      url: "",
       clone: jest.fn(),
       body: null,
       bodyUsed: false,
@@ -293,7 +296,7 @@ describe("GET match-info", () => {
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = await response.json() as ErrorResponse;
+    const json = (await response.json()) as ErrorResponse;
 
     expect(response.status).toBe(500);
     expect(json.error).toEqual("Failed to fetch match info");
@@ -301,27 +304,30 @@ describe("GET match-info", () => {
 });
 
 describe("GET match-timeline", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it("returns 400 if matchId is excluded", async () => {
     const url = new URL("http://localhost/api/riot?action=match-timeline");
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = await response.json() as ErrorResponse;
+    const json = (await response.json()) as ErrorResponse;
 
     expect(response.status).toBe(400);
     expect(json.error).toBe("matchId is required for match timeline lookup");
   });
   it("returns 200 with match info if valid match id", async () => {
-    const mockResponse: MatchInfoResponse = { metadata: {} };
+    const mockResponse: RiotMatchTimelineResponse = { metadata: {}, info: {} };
     (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
       ok: true,
       json: async () => mockResponse,
       headers: new Headers(),
       redirected: false,
       status: 200,
-      statusText: 'OK',
-      type: 'basic',
-      url: '',
+      statusText: "OK",
+      type: "basic",
+      url: "",
       clone: jest.fn(),
       body: null,
       bodyUsed: false,
@@ -337,7 +343,7 @@ describe("GET match-timeline", () => {
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = await response.json() as MatchInfoResponse;
+    const json = (await response.json()) as RiotMatchTimelineResponse;
 
     expect(response.status).toBe(200);
     expect(json).toEqual(mockResponse);
@@ -354,9 +360,9 @@ describe("GET match-timeline", () => {
       headers: new Headers(),
       redirected: false,
       status: 404,
-      statusText: 'Not Found',
-      type: 'basic',
-      url: '',
+      statusText: "Not Found",
+      type: "basic",
+      url: "",
       clone: jest.fn(),
       body: null,
       bodyUsed: false,
@@ -372,7 +378,7 @@ describe("GET match-timeline", () => {
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = await response.json() as ErrorResponse;
+    const json = (await response.json()) as ErrorResponse;
 
     expect(response.status).toBe(500);
     expect(json.error).toEqual("Failed to fetch match timeline");

--- a/src/app/api/riot/route.ts
+++ b/src/app/api/riot/route.ts
@@ -1,30 +1,35 @@
-import type { NextRequest } from 'next/server';
-import { NextResponse } from 'next/server';
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import {
+  fetchAccount,
+  fetchMatchHistory,
+  fetchMatchInfo,
+  fetchMatchTimeline,
+} from "~/lib/riot";
 
-const API_KEY = process.env.RIOT_API_KEY;
+import type {
+  RiotAccountResponse,
+  RiotMatchHistoryResponse,
+  RiotMatchInfoResponse,
+  RiotMatchTimelineResponse,
+} from "~/types/riot";
 
-if (!API_KEY) {
-  throw new Error('RIOT_API_KEY environment variable is not set');
-}
-
-const riotApiKey: string = API_KEY;
-const BASE_URL = "https://americas.api.riotgames.com";
-
+import type { ErrorResponse } from "~/types/error";
 /**
  * Riot Games API Route
- * 
+ *
  * Endpoints:
- * 
+ *
  * 1. Account Lookup:
  *    GET /api/riot?action=account&gameName=<name>&tagLine=<tag>
  *    Returns account information including PUUID
- * 
+ *
  * 2. Match History:
  *    GET /api/riot?action=match-history&puuid=<puuid>&[optional_params]
- *    
+ *
  *    Required parameters:
  *    - puuid: Player's unique identifier
- *    
+ *
  *    Optional parameters:
  *    - start: Start index (default: 0)
  *    - count: Number of matches to return, 0-100 (default: 100)
@@ -32,21 +37,21 @@ const BASE_URL = "https://americas.api.riotgames.com";
  *    - endTime: Epoch timestamp in seconds
  *    - queue: Queue ID filter (mutually inclusive with type)
  *    - type: Match type filter - "ranked" (mutually inclusive with queue)
- * 
+ *
  * 3. Match Info:
  *    GET /api/riot?action=match-info&matchId=<matchId>
  *    Returns detailed match information
- *    
+ *
  *    Required parameters:
  *    - matchId: Match identifier (e.g., "NA1_5371575881")
- * 
+ *
  * 4. Match Timeline:
  *    GET /api/riot?action=match-timeline&matchId=<matchId>
  *    Returns match timeline data with events
- *    
+ *
  *    Required parameters:
  *    - matchId: Match identifier (e.g., "NA1_5371575881")
- * 
+ *
  * Examples:
  * - Basic match history: /api/riot?action=match-history&puuid=<puuid>
  * - Recent 20 matches: /api/riot?action=match-history&puuid=<puuid>&count=20
@@ -58,164 +63,130 @@ const BASE_URL = "https://americas.api.riotgames.com";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
-  const action = searchParams.get('action');
-  const gameName = searchParams.get('gameName');
-  const tagLine = searchParams.get('tagLine');
-  const puuid = searchParams.get('puuid');
-  const matchId = searchParams.get('matchId');
+  const action = searchParams.get("action");
+  const gameName = searchParams.get("gameName");
+  const tagLine = searchParams.get("tagLine");
+  const puuid = searchParams.get("puuid");
+  const matchId = searchParams.get("matchId");
 
   try {
     switch (action) {
-      case 'account':
+      case "account":
         if (!gameName || !tagLine) {
           return NextResponse.json(
-            { error: 'gameName and tagLine are required for account lookup' },
-            { status: 400 }
+            { error: "gameName and tagLine are required for account lookup" },
+            { status: 400 },
           );
         }
         return await getAccount(gameName, tagLine);
 
-      case 'match-history':
+      case "match-history":
         if (!puuid) {
           return NextResponse.json(
-            { error: 'puuid is required for match history lookup' },
-            { status: 400 }
+            { error: "puuid is required for match history lookup" },
+            { status: 400 },
           );
         }
         return await getMatchHistory(puuid, searchParams);
 
-      case 'match-info':
+      case "match-info":
         if (!matchId) {
           return NextResponse.json(
-            { error: 'matchId is required for match info lookup' },
-            { status: 400 }
+            { error: "matchId is required for match info lookup" },
+            { status: 400 },
           );
         }
         return await getMatchInfo(matchId);
 
-      case 'match-timeline':
+      case "match-timeline":
         if (!matchId) {
           return NextResponse.json(
-            { error: 'matchId is required for match timeline lookup' },
-            { status: 400 }
+            { error: "matchId is required for match timeline lookup" },
+            { status: 400 },
           );
         }
         return await getMatchTimeline(matchId);
 
       default:
         return NextResponse.json(
-          { error: 'Invalid action. Use "account", "match-history", "match-info", or "match-timeline"' },
-          { status: 400 }
+          {
+            error:
+              'Invalid action. Use "account", "match-history", "match-info", or "match-timeline"',
+          },
+          { status: 400 },
         );
     }
   } catch (error) {
-    console.error('API Error:', error);
+    console.error("API Error:", error);
     return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
+      { error: "Internal server error" },
+      { status: 500 },
     );
   }
 }
 
-async function getAccount(gameName: string, tagLine: string) {
-  const url = `${BASE_URL}/riot/account/v1/accounts/by-riot-id/${gameName}/${tagLine}`;
-  
+async function getAccount(
+  gameName: string,
+  tagLine: string,
+): Promise<NextResponse<RiotAccountResponse | ErrorResponse>> {
   try {
-    const res = await fetch(url, {
-      headers: {
-        "X-Riot-Token": riotApiKey
-      }
-    });
-
-    if (!res.ok) {
-      throw new Error(`Request failed with ${res.status}: ${await res.text()}`);
-    }
-
-    const data = await res.json() as Record<string, unknown>;
+    const data: RiotAccountResponse = await fetchAccount(gameName, tagLine);
     return NextResponse.json(data);
   } catch (err) {
     console.error("Error fetching account:", err);
-    return NextResponse.json(
-      { error: 'Failed to fetch account data' },
-      { status: 500 }
+    return NextResponse.json<ErrorResponse>(
+      { error: "Failed to fetch account data" },
+      { status: 500 },
     );
   }
 }
 
-async function getMatchHistory(puuid: string, searchParams: URLSearchParams) {
-  const params = new URLSearchParams();
-  params.append('api_key', riotApiKey);
-  
-  const start = searchParams.get('start') ?? '0';
-  const count = searchParams.get('count') ?? '100';
-  params.append('start', start);
-  params.append('count', count);
-  
-  const startTime = searchParams.get('startTime');
-  const endTime = searchParams.get('endTime');
-  const queue = searchParams.get('queue');
-  const type = searchParams.get('type');
-  
-  if (startTime) params.append('startTime', startTime);
-  if (endTime) params.append('endTime', endTime);
-  if (queue) params.append('queue', queue);
-  if (type) params.append('type', type);
-  
-  const url = `${BASE_URL}/lol/match/v5/matches/by-puuid/${puuid}/ids?${params.toString()}`;
-  
+async function getMatchHistory(
+  puuid: string,
+  searchParams: URLSearchParams,
+): Promise<NextResponse<RiotMatchHistoryResponse | ErrorResponse>> {
   try {
-    const res = await fetch(url);
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status}: ${await res.text()}`);
-    }
-    
-    const matchIds = await res.json() as string[];
-    return NextResponse.json({ matchIds });
+    const data: RiotMatchHistoryResponse = await fetchMatchHistory(
+      puuid,
+      searchParams,
+    );
+    return NextResponse.json(data);
   } catch (err) {
     console.error("Failed to fetch match IDs:", err);
-    return NextResponse.json(
-      { error: 'Failed to fetch match history' },
-      { status: 500 }
+    return NextResponse.json<ErrorResponse>(
+      { error: "Failed to fetch match history" },
+      { status: 500 },
     );
   }
 }
 
-async function getMatchInfo(matchId: string) {
-  const url = `${BASE_URL}/lol/match/v5/matches/${matchId}?api_key=${riotApiKey}`;
-  
+async function getMatchInfo(
+  matchId: string,
+): Promise<NextResponse<RiotMatchInfoResponse | ErrorResponse>> {
   try {
-    const res = await fetch(url);
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status}: ${await res.text()}`);
-    }
-    
-    const matchInfo = await res.json() as Record<string, unknown>;
+    const matchInfo: RiotMatchInfoResponse = await fetchMatchInfo(matchId);
     return NextResponse.json(matchInfo);
   } catch (err) {
     console.error("Failed to fetch match info:", err);
-    return NextResponse.json(
-      { error: 'Failed to fetch match info' },
-      { status: 500 }
+    return NextResponse.json<ErrorResponse>(
+      { error: "Failed to fetch match info" },
+      { status: 500 },
     );
   }
 }
 
-async function getMatchTimeline(matchId: string) {
-  const url = `${BASE_URL}/lol/match/v5/matches/${matchId}/timeline?api_key=${riotApiKey}`;
-  
+async function getMatchTimeline(
+  matchId: string,
+): Promise<NextResponse<RiotMatchTimelineResponse | ErrorResponse>> {
   try {
-    const res = await fetch(url);
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status}: ${await res.text()}`);
-    }
-    
-    const timeline = await res.json() as Record<string, unknown>;
+    const timeline: RiotMatchTimelineResponse =
+      await fetchMatchTimeline(matchId);
     return NextResponse.json(timeline);
   } catch (err) {
     console.error("Failed to fetch match timeline:", err);
-    return NextResponse.json(
-      { error: 'Failed to fetch match timeline' },
-      { status: 500 }
+    return NextResponse.json<ErrorResponse>(
+      { error: "Failed to fetch match timeline" },
+      { status: 500 },
     );
   }
 }

--- a/src/lib/riot.test.ts
+++ b/src/lib/riot.test.ts
@@ -1,0 +1,134 @@
+import {
+  fetchAccount,
+  fetchMatchHistory,
+  fetchMatchInfo,
+  fetchMatchTimeline,
+} from "~/lib/riot";
+
+import type {
+  RiotAccountResponse,
+  RiotMatchHistoryResponse,
+  RiotMatchInfoResponse,
+  RiotMatchTimelineResponse,
+} from "~/types/riot";
+
+// Mock the global fetch function
+global.fetch = jest.fn();
+
+describe("Riot API helpers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("fetchAccount", () => {
+    it("returns data when fetch succeeds", async () => {
+      const mockData: RiotAccountResponse = {
+        puuid: "puuid123",
+        gameName: "Summoner",
+        tagLine: "NA1",
+      };
+
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockData,
+      } as Response);
+
+      const result = await fetchAccount("Summoner", "NA1");
+      expect(result).toEqual(mockData);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws an error when fetch fails", async () => {
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: async () => "Not Found",
+      } as Response);
+
+      await expect(fetchAccount("Summoner", "NA1")).rejects.toThrow(
+        /Request failed/,
+      );
+    });
+  });
+
+  describe("fetchMatchHistory", () => {
+    it("returns match ids when fetch succeeds", async () => {
+      const mockData: RiotMatchHistoryResponse = ["NA1_123", "NA1_456"];
+
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockData,
+      } as Response);
+
+      const result = await fetchMatchHistory("puuid123", new URLSearchParams());
+      expect(result).toEqual(mockData);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws an error when fetch fails", async () => {
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => "Server Error",
+      } as Response);
+
+      await expect(
+        fetchMatchHistory("puuid123", new URLSearchParams()),
+      ).rejects.toThrow(/HTTP 500/);
+    });
+  });
+
+  describe("fetchMatchInfo", () => {
+    it("returns match info when fetch succeeds", async () => {
+      const mockData: RiotMatchInfoResponse = {
+        // populate with minimal fields needed for the type
+      } as RiotMatchInfoResponse;
+
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockData,
+      } as Response);
+
+      const result = await fetchMatchInfo("match123");
+      expect(result).toEqual(mockData);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws an error when fetch fails", async () => {
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: async () => "Not Found",
+      } as Response);
+
+      await expect(fetchMatchInfo("match123")).rejects.toThrow(/HTTP 404/);
+    });
+  });
+
+  describe("fetchMatchTimeline", () => {
+    it("returns timeline data when fetch succeeds", async () => {
+      const mockData: RiotMatchTimelineResponse = {
+        // minimal fields for the type
+      } as RiotMatchTimelineResponse;
+
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockData,
+      } as Response);
+
+      const result = await fetchMatchTimeline("match123");
+      expect(result).toEqual(mockData);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws an error when fetch fails", async () => {
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => "Server Error",
+      } as Response);
+
+      await expect(fetchMatchTimeline("match123")).rejects.toThrow(/HTTP 500/);
+    });
+  });
+});

--- a/src/lib/riot.ts
+++ b/src/lib/riot.ts
@@ -1,0 +1,129 @@
+import type {
+  RiotAccountResponse,
+  RiotMatchHistoryResponse,
+  RiotMatchInfoResponse,
+  RiotMatchTimelineResponse,
+} from "~/types/riot";
+
+const API_KEY = process.env.RIOT_API_KEY;
+
+if (!API_KEY) {
+  throw new Error("RIOT_API_KEY environment variable is not set");
+}
+
+const riotApiKey: string = API_KEY;
+const BASE_URL = "https://americas.api.riotgames.com";
+
+/**
+ * Accesses the riot API to get a user's puuid for use in other riot API calls.
+ *
+ * See the [Riot API docs]("https://developer.riotgames.com/apis#account-v1/GET_getByRiotId")
+ *
+ * @param gameName - player's summoner name
+ * @param tagLine - player's tag line (unique identifier alongside gameName)
+ * @returns A promise for a {@link RiotAccountResponse} - throws an error when query fails
+ */
+export async function fetchAccount(
+  gameName: string,
+  tagLine: string,
+): Promise<RiotAccountResponse> {
+  const url = `${BASE_URL}/riot/account/v1/accounts/by-riot-id/${gameName}/${tagLine}`;
+
+  const res = await fetch(url, {
+    headers: {
+      "X-Riot-Token": riotApiKey,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Request failed with ${res.status}: ${await res.text()}`);
+  }
+  const data = (await res.json()) as RiotAccountResponse;
+  return data;
+}
+
+/**
+ * Accesses the riot API to get the match ids in a player's match history
+ *
+ * See the [Riot API docs]("https://developer.riotgames.com/apis#match-v5/GET_getMatchIdsByPUUID")
+ *
+ * @param puuid - the player's unique identifier
+ * @param searchParams - search parameters for the riot api
+ * @returns A promise for a {@link RiotMatchHistoryResponse} - throws an error when query fails
+ */
+export async function fetchMatchHistory(
+  puuid: string,
+  searchParams: URLSearchParams,
+): Promise<RiotMatchHistoryResponse> {
+  const params = new URLSearchParams();
+  params.append("api_key", riotApiKey);
+
+  const start = searchParams.get("start") ?? "0";
+  const count = searchParams.get("count") ?? "100";
+  params.append("start", start);
+  params.append("count", count);
+
+  const startTime = searchParams.get("startTime");
+  const endTime = searchParams.get("endTime");
+  const queue = searchParams.get("queue");
+  const type = searchParams.get("type");
+
+  if (startTime) params.append("startTime", startTime);
+  if (endTime) params.append("endTime", endTime);
+  if (queue) params.append("queue", queue);
+  if (type) params.append("type", type);
+
+  const url = `${BASE_URL}/lol/match/v5/matches/by-puuid/${puuid}/ids?${params.toString()}`;
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  }
+
+  const matchIds = (await res.json()) as RiotMatchHistoryResponse;
+  return matchIds;
+}
+
+/**
+ * Accesses the riot API to get match info for a given match id
+ *
+ * See the [Riot API docs]("https://developer.riotgames.com/apis#match-v5/GET_getMatch")
+ *
+ * @param matchId - a unique identifier for a match
+ * @returns A promise for a {@link RiotMatchInfoResponse}
+ */
+export async function fetchMatchInfo(
+  matchId: string,
+): Promise<RiotMatchInfoResponse> {
+  const url = `${BASE_URL}/lol/match/v5/matches/${matchId}?api_key=${riotApiKey}`;
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  }
+
+  const matchInfo = (await res.json()) as RiotMatchInfoResponse;
+  return matchInfo;
+}
+
+/**
+ * Accesses the riot API to get a timeline for a given match
+ *
+ * See the [Riot API docs]("https://developer.riotgames.com/apis#match-v5/GET_getTimeline")
+ *
+ * @param matchId - a unique identifier for a match
+ * @returns A promise for a {@link RiotMatchTimelineResponse}
+ */
+export async function fetchMatchTimeline(
+  matchId: string,
+): Promise<RiotMatchTimelineResponse> {
+  const url = `${BASE_URL}/lol/match/v5/matches/${matchId}/timeline?api_key=${riotApiKey}`;
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  }
+
+  const timeline = (await res.json()) as RiotMatchTimelineResponse;
+  return timeline;
+}

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -1,0 +1,3 @@
+export interface ErrorResponse {
+  error: string;
+}

--- a/src/types/riot.ts
+++ b/src/types/riot.ts
@@ -1,0 +1,17 @@
+export interface RiotAccountResponse {
+  puuid: string;
+  gameName: string;
+  tagLine: string;
+}
+
+export type RiotMatchHistoryResponse = string[];
+
+export interface RiotMatchInfoResponse {
+  metadata: Record<string, unknown>;
+  info: Record<string, unknown>;
+}
+
+export interface RiotMatchTimelineResponse {
+  metadata: Record<string, unknown>;
+  info: Record<string, unknown>;
+}


### PR DESCRIPTION
## Changes
- Created interfaces in the `/types/` folder for the API responses so they can be more easily seen, interpreted, and typed in any code that needs to use the `api/riot/` route.
- API calls to Riot were moved to a utility file inside `/lib/`. 
- Included new interfaces in the utility file and riot route (functions now state they return a promise of their respective interface)
- Updated route tests to include new interfaces in their typing + removed old interfaces inside the test file.
- Added new tests for the utility file.
- Updated jest file to use absolute paths.

## Motivation
The original riot route had a few small problems. For starters, most responses were records that always need to be null-checked, cast, etc, by whatever makes the request. Additionally, the return type did not clarify the information being sent; you would have to check the Riot API and make a query yourself to know what the response body should contain. Adding interfaces fixes this, allowing a developer to just Ctrl+click the interface in code to see (roughly) what to expect for the simple queries. They are quick to change, simple to understand, and make code more readable.

Additionally, it is quicker and easier for server components to query the riot api directly and get a promise instead of using the route and dealing with a NextResponse, which wasn't possible with the old configuration. Now, any server-side components can call the helper functions and avoid using the route (client-side components still need the route, however).

## Future Considerations
Add links/docs for the interfaces (a link to the riot api would be convenient!). I don't want to change this right now since I have already rebased another branch on this one, and I don't want to do it twice.