### PR TITLE
Route, Tests and Scripts Edit

### DIFF
--- a/scripts/fetch_match_history.mjs
+++ b/scripts/fetch_match_history.mjs
@@ -1,10 +1,10 @@
-const API_KEY = "RGAPI-14d98752-4a87-42e2-b27c-2f2b4aa7ab6b";
+const RIOT_API_KEY = "";
 const puuid = "6aRgHzMxyiZYg1bLGe7lAzgV8dgrU2OH5kERLffwt3Aaljz62aub2CgLJ4rm0DhGby37StURRQBvOg";
 const baseUrl = "https://americas.api.riotgames.com";
 const endpoint = `/lol/match/v5/matches/by-puuid/${puuid}/ids?start=0&count=100`;
 
 async function fetchMatchIds() {
-  const url = `${baseUrl}${endpoint}&api_key=${API_KEY}`;
+  const url = `${baseUrl}${endpoint}&api_key=${RIOT_API_KEY}`;
   try {
     const res = await fetch(url);
     if (!res.ok) {

--- a/scripts/fetch_match_info.mjs
+++ b/scripts/fetch_match_info.mjs
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-const API_KEY = "RGAPI-14d98752-4a87-42e2-b27c-2f2b4aa7ab6b";
+const RIOT_API_KEY = "";
 const matchId = "NA1_5371575881";
 
 const baseUrl = "https://americas.api.riotgames.com";

--- a/scripts/fetch_match_timeline.mjs
+++ b/scripts/fetch_match_timeline.mjs
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-const API_KEY = "RGAPI-14d98752-4a87-42e2-b27c-2f2b4aa7ab6b";
+const RIOT_API_KEY = "";
 const matchId = "NA1_5371642334";
 
 const baseUrl = "https://americas.api.riotgames.com";

--- a/scripts/fetch_puuid.mjs
+++ b/scripts/fetch_puuid.mjs
@@ -1,11 +1,11 @@
-const API_KEY = "RGAPI-14d98752-4a87-42e2-b27c-2f2b4aa7ab6b";
+const RIOT_API_KEY = "";
 const url = "https://americas.api.riotgames.com/riot/account/v1/accounts/by-riot-id/c9loki/kr3";
 
 async function getAccount() {
   try {
     const res = await fetch(url, {
       headers: {
-        "X-Riot-Token": API_KEY
+        "X-Riot-Token": RIOT_API_KEY
       }
     });
 

--- a/src/app/api/riot/route.test.ts
+++ b/src/app/api/riot/route.test.ts
@@ -69,7 +69,8 @@ describe("GET account", () => {
       gameName: "TestUser",
       tagLine: "testTag",
     };
-    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+    
+    const mockResponseObj = {
       ok: true,
       json: async () => mockResponse,
       headers: new Headers(),
@@ -78,7 +79,6 @@ describe("GET account", () => {
       statusText: "OK",
       type: "basic",
       url: "",
-      clone: jest.fn(),
       body: null,
       bodyUsed: false,
       arrayBuffer: jest.fn(),
@@ -86,7 +86,10 @@ describe("GET account", () => {
       formData: jest.fn(),
       text: jest.fn(),
       bytes: jest.fn(),
-    } as unknown as Response);
+      clone: jest.fn().mockReturnThis(),
+    };
+    
+    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockResponseObj as unknown as Response);
     const url = new URL(
       "http://localhost/api/riot?action=account&gameName=TestUser&tagLine=testTag",
     );
@@ -98,7 +101,7 @@ describe("GET account", () => {
     expect(response.status).toBe(200);
     expect(json).toEqual(mockResponse);
   });
-  it("returns 500 if invalid gameName and tagLine are set", async () => {
+  it("returns 404 if invalid gameName and tagLine are set", async () => {
     const mockResponse = {
       status: {
         status_code: 404,
@@ -106,7 +109,8 @@ describe("GET account", () => {
           "Data not found - No results found for player with riot id TestUser#testTag",
       },
     };
-    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+    
+    const mockResponseObj = {
       ok: false,
       json: async () => mockResponse,
       headers: new Headers(),
@@ -115,7 +119,6 @@ describe("GET account", () => {
       statusText: "Not Found",
       type: "basic",
       url: "",
-      clone: jest.fn(),
       body: null,
       bodyUsed: false,
       arrayBuffer: jest.fn(),
@@ -123,17 +126,20 @@ describe("GET account", () => {
       formData: jest.fn(),
       text: jest.fn(),
       bytes: jest.fn(),
-    } as unknown as Response);
+      clone: jest.fn().mockReturnThis(),
+    };
+    
+    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockResponseObj as unknown as Response);
     const url = new URL(
       "http://localhost/api/riot?action=account&gameName=TestUser&tagLine=testTag",
     );
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = (await response.json()) as ErrorResponse;
+    const json = (await response.json());
 
-    expect(response.status).toBe(500);
-    expect(json.error).toEqual("Failed to fetch account data");
+    expect(response.status).toBe(404);
+    expect(json).toEqual(mockResponse);
   });
 });
 
@@ -154,7 +160,8 @@ describe("GET match-history", () => {
   it("returns 200 with match history if valid puuid", async () => {
     const matches = ["NA_testmatch1", "NA_testmatch2"];
     const mockResponse: RiotMatchHistoryResponse = matches;
-    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+    
+    const mockResponseObj = {
       ok: true,
       json: async () => matches,
       headers: new Headers(),
@@ -163,7 +170,6 @@ describe("GET match-history", () => {
       statusText: "OK",
       type: "basic",
       url: "",
-      clone: jest.fn(),
       body: null,
       bodyUsed: false,
       arrayBuffer: jest.fn(),
@@ -171,7 +177,10 @@ describe("GET match-history", () => {
       formData: jest.fn(),
       text: jest.fn(),
       bytes: jest.fn(),
-    } as unknown as Response);
+      clone: jest.fn().mockReturnThis(),
+    };
+    
+    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockResponseObj as unknown as Response);
     const url = new URL(
       "http://localhost/api/riot?action=match-history&puuid=12345",
     );
@@ -183,14 +192,15 @@ describe("GET match-history", () => {
     expect(response.status).toBe(200);
     expect(json).toEqual(mockResponse);
   });
-  it("returns 500 if invalid puuid is set", async () => {
+  it("returns 404 if invalid puuid is set", async () => {
     const mockResponse = {
       status: {
         message: "Bad Request - Exception decrypting 12345",
         status_code: 400,
       },
     };
-    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+    
+    const mockResponseObj = {
       ok: false,
       json: async () => mockResponse,
       headers: new Headers(),
@@ -199,7 +209,6 @@ describe("GET match-history", () => {
       statusText: "Not Found",
       type: "basic",
       url: "",
-      clone: jest.fn(),
       body: null,
       bodyUsed: false,
       arrayBuffer: jest.fn(),
@@ -207,17 +216,20 @@ describe("GET match-history", () => {
       formData: jest.fn(),
       text: jest.fn(),
       bytes: jest.fn(),
-    } as unknown as Response);
+      clone: jest.fn().mockReturnThis(),
+    };
+    
+    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockResponseObj as unknown as Response);
     const url = new URL(
       "http://localhost/api/riot?action=match-history&puuid=12345",
     );
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = (await response.json()) as ErrorResponse;
+    const json = (await response.json());
 
-    expect(response.status).toBe(500);
-    expect(json.error).toEqual("Failed to fetch match history");
+    expect(response.status).toBe(404);
+    expect(json).toEqual(mockResponse);
   });
 });
 
@@ -237,7 +249,8 @@ describe("GET match-info", () => {
   });
   it("returns 200 with match info if valid match id", async () => {
     const mockResponse: RiotMatchInfoResponse = { metadata: {}, info: {} };
-    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+    
+    const mockResponseObj = {
       ok: true,
       json: async () => mockResponse,
       headers: new Headers(),
@@ -246,7 +259,6 @@ describe("GET match-info", () => {
       statusText: "OK",
       type: "basic",
       url: "",
-      clone: jest.fn(),
       body: null,
       bodyUsed: false,
       arrayBuffer: jest.fn(),
@@ -254,7 +266,10 @@ describe("GET match-info", () => {
       formData: jest.fn(),
       text: jest.fn(),
       bytes: jest.fn(),
-    } as unknown as Response);
+      clone: jest.fn().mockReturnThis(),
+    };
+    
+    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockResponseObj as unknown as Response);
     const url = new URL(
       "http://localhost/api/riot?action=match-info&matchId=NA_testmatch",
     );
@@ -266,13 +281,14 @@ describe("GET match-info", () => {
     expect(response.status).toBe(200);
     expect(json).toEqual(mockResponse);
   });
-  it("returns 500 if invalid match id is set", async () => {
+  it("returns 404 if invalid match id is set", async () => {
     const mockResponse = {
       httpStatus: 404,
       errorCode: "RESOURCE_NOT_FOUND",
       message: "match file not found",
     };
-    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+    
+    const mockResponseObj = {
       ok: false,
       json: async () => mockResponse,
       headers: new Headers(),
@@ -281,7 +297,6 @@ describe("GET match-info", () => {
       statusText: "Not Found",
       type: "basic",
       url: "",
-      clone: jest.fn(),
       body: null,
       bodyUsed: false,
       arrayBuffer: jest.fn(),
@@ -289,17 +304,20 @@ describe("GET match-info", () => {
       formData: jest.fn(),
       text: jest.fn(),
       bytes: jest.fn(),
-    } as unknown as Response);
+      clone: jest.fn().mockReturnThis(),
+    };
+    
+    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockResponseObj as unknown as Response);
     const url = new URL(
       "http://localhost/api/riot?action=match-info&matchId=NA_testmatch",
     );
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = (await response.json()) as ErrorResponse;
+    const json = (await response.json());
 
-    expect(response.status).toBe(500);
-    expect(json.error).toEqual("Failed to fetch match info");
+    expect(response.status).toBe(404);
+    expect(json).toEqual(mockResponse);
   });
 });
 
@@ -319,7 +337,8 @@ describe("GET match-timeline", () => {
   });
   it("returns 200 with match info if valid match id", async () => {
     const mockResponse: RiotMatchTimelineResponse = { metadata: {}, info: {} };
-    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+    
+    const mockResponseObj = {
       ok: true,
       json: async () => mockResponse,
       headers: new Headers(),
@@ -328,7 +347,6 @@ describe("GET match-timeline", () => {
       statusText: "OK",
       type: "basic",
       url: "",
-      clone: jest.fn(),
       body: null,
       bodyUsed: false,
       arrayBuffer: jest.fn(),
@@ -336,7 +354,10 @@ describe("GET match-timeline", () => {
       formData: jest.fn(),
       text: jest.fn(),
       bytes: jest.fn(),
-    } as unknown as Response);
+      clone: jest.fn().mockReturnThis(),
+    };
+    
+    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockResponseObj as unknown as Response);
     const url = new URL(
       "http://localhost/api/riot?action=match-timeline&matchId=NA_testmatch",
     );
@@ -348,13 +369,14 @@ describe("GET match-timeline", () => {
     expect(response.status).toBe(200);
     expect(json).toEqual(mockResponse);
   });
-  it("returns 500 if invalid match id is set", async () => {
+  it("returns 404 if invalid match id is set", async () => {
     const mockResponse = {
       httpStatus: 404,
       errorCode: "RESOURCE_NOT_FOUND",
       message: "match file not found",
     };
-    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+    
+    const mockResponseObj = {
       ok: false,
       json: async () => mockResponse,
       headers: new Headers(),
@@ -363,7 +385,6 @@ describe("GET match-timeline", () => {
       statusText: "Not Found",
       type: "basic",
       url: "",
-      clone: jest.fn(),
       body: null,
       bodyUsed: false,
       arrayBuffer: jest.fn(),
@@ -371,16 +392,19 @@ describe("GET match-timeline", () => {
       formData: jest.fn(),
       text: jest.fn(),
       bytes: jest.fn(),
-    } as unknown as Response);
+      clone: jest.fn().mockReturnThis(),
+    };
+    
+    (mockFetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(mockResponseObj as unknown as Response);
     const url = new URL(
       "http://localhost/api/riot?action=match-timeline&matchId=NA_testmatch",
     );
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = (await response.json()) as ErrorResponse;
+    const json = (await response.json());
 
-    expect(response.status).toBe(500);
-    expect(json.error).toEqual("Failed to fetch match timeline");
+    expect(response.status).toBe(404);
+    expect(json).toEqual(mockResponse);
   });
 });

--- a/src/app/api/riot/route.test.ts
+++ b/src/app/api/riot/route.test.ts
@@ -136,7 +136,7 @@ describe("GET account", () => {
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = (await response.json());
+    const json = (await response.json()) as unknown;
 
     expect(response.status).toBe(404);
     expect(json).toEqual(mockResponse);
@@ -226,7 +226,7 @@ describe("GET match-history", () => {
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = (await response.json());
+    const json = (await response.json()) as unknown;
 
     expect(response.status).toBe(404);
     expect(json).toEqual(mockResponse);
@@ -314,7 +314,7 @@ describe("GET match-info", () => {
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = (await response.json());
+    const json = (await response.json()) as unknown;
 
     expect(response.status).toBe(404);
     expect(json).toEqual(mockResponse);
@@ -402,7 +402,7 @@ describe("GET match-timeline", () => {
     const request = new NextRequest(url);
 
     const response = await GET(request);
-    const json = (await response.json());
+    const json = (await response.json()) as unknown;
 
     expect(response.status).toBe(404);
     expect(json).toEqual(mockResponse);

--- a/src/app/api/riot/route.ts
+++ b/src/app/api/riot/route.ts
@@ -123,7 +123,7 @@ async function getAccount(
   const response = await fetchAccount(gameName, tagLine);
   
   const responseClone = response.clone();
-  const data = await responseClone.json();
+  const data = await responseClone.json() as unknown;
   
   return NextResponse.json(data, { status: response.status });
 }
@@ -134,7 +134,7 @@ async function getMatchHistory(
 ): Promise<NextResponse> {
   const response = await fetchMatchHistory(puuid, searchParams);
   const responseClone = response.clone();
-  const data = await responseClone.json();
+  const data = await responseClone.json() as unknown;
   
   return NextResponse.json(data, { status: response.status });
 }
@@ -144,7 +144,7 @@ async function getMatchInfo(
 ): Promise<NextResponse> {
   const response = await fetchMatchInfo(matchId);
   const responseClone = response.clone();
-  const data = await responseClone.json();
+  const data = await responseClone.json() as unknown;
   
   return NextResponse.json(data, { status: response.status });
 }
@@ -154,7 +154,7 @@ async function getMatchTimeline(
 ): Promise<NextResponse> {
   const response = await fetchMatchTimeline(matchId);
   const responseClone = response.clone();
-  const data = await responseClone.json();
+  const data = await responseClone.json() as unknown;
   
   return NextResponse.json(data, { status: response.status });
 }

--- a/src/app/api/riot/route.ts
+++ b/src/app/api/riot/route.ts
@@ -6,15 +6,6 @@ import {
   fetchMatchInfo,
   fetchMatchTimeline,
 } from "~/lib/riot";
-
-import type {
-  RiotAccountResponse,
-  RiotMatchHistoryResponse,
-  RiotMatchInfoResponse,
-  RiotMatchTimelineResponse,
-} from "~/types/riot";
-
-import type { ErrorResponse } from "~/types/error";
 /**
  * Riot Games API Route
  *
@@ -128,65 +119,42 @@ export async function GET(request: NextRequest) {
 async function getAccount(
   gameName: string,
   tagLine: string,
-): Promise<NextResponse<RiotAccountResponse | ErrorResponse>> {
-  try {
-    const data: RiotAccountResponse = await fetchAccount(gameName, tagLine);
-    return NextResponse.json(data);
-  } catch (err) {
-    console.error("Error fetching account:", err);
-    return NextResponse.json<ErrorResponse>(
-      { error: "Failed to fetch account data" },
-      { status: 500 },
-    );
-  }
+): Promise<NextResponse> {
+  const response = await fetchAccount(gameName, tagLine);
+  
+  const responseClone = response.clone();
+  const data = await responseClone.json();
+  
+  return NextResponse.json(data, { status: response.status });
 }
 
 async function getMatchHistory(
   puuid: string,
   searchParams: URLSearchParams,
-): Promise<NextResponse<RiotMatchHistoryResponse | ErrorResponse>> {
-  try {
-    const data: RiotMatchHistoryResponse = await fetchMatchHistory(
-      puuid,
-      searchParams,
-    );
-    return NextResponse.json(data);
-  } catch (err) {
-    console.error("Failed to fetch match IDs:", err);
-    return NextResponse.json<ErrorResponse>(
-      { error: "Failed to fetch match history" },
-      { status: 500 },
-    );
-  }
+): Promise<NextResponse> {
+  const response = await fetchMatchHistory(puuid, searchParams);
+  const responseClone = response.clone();
+  const data = await responseClone.json();
+  
+  return NextResponse.json(data, { status: response.status });
 }
 
 async function getMatchInfo(
   matchId: string,
-): Promise<NextResponse<RiotMatchInfoResponse | ErrorResponse>> {
-  try {
-    const matchInfo: RiotMatchInfoResponse = await fetchMatchInfo(matchId);
-    return NextResponse.json(matchInfo);
-  } catch (err) {
-    console.error("Failed to fetch match info:", err);
-    return NextResponse.json<ErrorResponse>(
-      { error: "Failed to fetch match info" },
-      { status: 500 },
-    );
-  }
+): Promise<NextResponse> {
+  const response = await fetchMatchInfo(matchId);
+  const responseClone = response.clone();
+  const data = await responseClone.json();
+  
+  return NextResponse.json(data, { status: response.status });
 }
 
 async function getMatchTimeline(
   matchId: string,
-): Promise<NextResponse<RiotMatchTimelineResponse | ErrorResponse>> {
-  try {
-    const timeline: RiotMatchTimelineResponse =
-      await fetchMatchTimeline(matchId);
-    return NextResponse.json(timeline);
-  } catch (err) {
-    console.error("Failed to fetch match timeline:", err);
-    return NextResponse.json<ErrorResponse>(
-      { error: "Failed to fetch match timeline" },
-      { status: 500 },
-    );
-  }
+): Promise<NextResponse> {
+  const response = await fetchMatchTimeline(matchId);
+  const responseClone = response.clone();
+  const data = await responseClone.json();
+  
+  return NextResponse.json(data, { status: response.status });
 }

--- a/src/lib/riot.test.ts
+++ b/src/lib/riot.test.ts
@@ -21,114 +21,162 @@ describe("Riot API helpers", () => {
   });
 
   describe("fetchAccount", () => {
-    it("returns data when fetch succeeds", async () => {
+    it("returns response when fetch succeeds", async () => {
       const mockData: RiotAccountResponse = {
         puuid: "puuid123",
         gameName: "Summoner",
         tagLine: "NA1",
       };
 
-      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+      const mockResponse = {
         ok: true,
+        status: 200,
         json: async () => mockData,
-      } as Response);
+        clone: jest.fn().mockReturnThis(),
+      } as unknown as Response;
+
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(mockResponse);
 
       const result = await fetchAccount("Summoner", "NA1");
-      expect(result).toEqual(mockData);
+      expect(result).toBe(mockResponse);
+      expect(result.ok).toBe(true);
+      expect(result.status).toBe(200);
       expect(fetch).toHaveBeenCalledTimes(1);
     });
 
-    it("throws an error when fetch fails", async () => {
-      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+    it("returns response when fetch fails", async () => {
+      const mockResponse = {
         ok: false,
         status: 404,
         text: async () => "Not Found",
-      } as Response);
+        clone: jest.fn().mockReturnThis(),
+      } as unknown as Response;
 
-      await expect(fetchAccount("Summoner", "NA1")).rejects.toThrow(
-        /Request failed/,
-      );
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(mockResponse);
+
+      const result = await fetchAccount("Summoner", "NA1");
+      expect(result).toBe(mockResponse);
+      expect(result.ok).toBe(false);
+      expect(result.status).toBe(404);
+      expect(fetch).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("fetchMatchHistory", () => {
-    it("returns match ids when fetch succeeds", async () => {
+    it("returns response when fetch succeeds", async () => {
       const mockData: RiotMatchHistoryResponse = ["NA1_123", "NA1_456"];
 
-      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+      const mockResponse = {
         ok: true,
+        status: 200,
         json: async () => mockData,
-      } as Response);
+        clone: jest.fn().mockReturnThis(),
+      } as unknown as Response;
+
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(mockResponse);
 
       const result = await fetchMatchHistory("puuid123", new URLSearchParams());
-      expect(result).toEqual(mockData);
+      expect(result).toBe(mockResponse);
+      expect(result.ok).toBe(true);
+      expect(result.status).toBe(200);
       expect(fetch).toHaveBeenCalledTimes(1);
     });
 
-    it("throws an error when fetch fails", async () => {
-      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+    it("returns response when fetch fails", async () => {
+      const mockResponse = {
         ok: false,
         status: 500,
         text: async () => "Server Error",
-      } as Response);
+        clone: jest.fn().mockReturnThis(),
+      } as unknown as Response;
 
-      await expect(
-        fetchMatchHistory("puuid123", new URLSearchParams()),
-      ).rejects.toThrow(/HTTP 500/);
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(mockResponse);
+
+      const result = await fetchMatchHistory("puuid123", new URLSearchParams());
+      expect(result).toBe(mockResponse);
+      expect(result.ok).toBe(false);
+      expect(result.status).toBe(500);
+      expect(fetch).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("fetchMatchInfo", () => {
-    it("returns match info when fetch succeeds", async () => {
+    it("returns response when fetch succeeds", async () => {
       const mockData: RiotMatchInfoResponse = {
         // populate with minimal fields needed for the type
       } as RiotMatchInfoResponse;
 
-      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+      const mockResponse = {
         ok: true,
+        status: 200,
         json: async () => mockData,
-      } as Response);
+        clone: jest.fn().mockReturnThis(),
+      } as unknown as Response;
+
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(mockResponse);
 
       const result = await fetchMatchInfo("match123");
-      expect(result).toEqual(mockData);
+      expect(result).toBe(mockResponse);
+      expect(result.ok).toBe(true);
+      expect(result.status).toBe(200);
       expect(fetch).toHaveBeenCalledTimes(1);
     });
 
-    it("throws an error when fetch fails", async () => {
-      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+    it("returns response when fetch fails", async () => {
+      const mockResponse = {
         ok: false,
         status: 404,
         text: async () => "Not Found",
-      } as Response);
+        clone: jest.fn().mockReturnThis(),
+      } as unknown as Response;
 
-      await expect(fetchMatchInfo("match123")).rejects.toThrow(/HTTP 404/);
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(mockResponse);
+
+      const result = await fetchMatchInfo("match123");
+      expect(result).toBe(mockResponse);
+      expect(result.ok).toBe(false);
+      expect(result.status).toBe(404);
+      expect(fetch).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("fetchMatchTimeline", () => {
-    it("returns timeline data when fetch succeeds", async () => {
+    it("returns response when fetch succeeds", async () => {
       const mockData: RiotMatchTimelineResponse = {
         // minimal fields for the type
       } as RiotMatchTimelineResponse;
 
-      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+      const mockResponse = {
         ok: true,
+        status: 200,
         json: async () => mockData,
-      } as Response);
+        clone: jest.fn().mockReturnThis(),
+      } as unknown as Response;
+
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(mockResponse);
 
       const result = await fetchMatchTimeline("match123");
-      expect(result).toEqual(mockData);
+      expect(result).toBe(mockResponse);
+      expect(result.ok).toBe(true);
+      expect(result.status).toBe(200);
       expect(fetch).toHaveBeenCalledTimes(1);
     });
 
-    it("throws an error when fetch fails", async () => {
-      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce({
+    it("returns response when fetch fails", async () => {
+      const mockResponse = {
         ok: false,
         status: 500,
         text: async () => "Server Error",
-      } as Response);
+        clone: jest.fn().mockReturnThis(),
+      } as unknown as Response;
 
-      await expect(fetchMatchTimeline("match123")).rejects.toThrow(/HTTP 500/);
+      (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(mockResponse);
+
+      const result = await fetchMatchTimeline("match123");
+      expect(result).toBe(mockResponse);
+      expect(result.ok).toBe(false);
+      expect(result.status).toBe(500);
+      expect(fetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/lib/riot.ts
+++ b/src/lib/riot.ts
@@ -1,10 +1,3 @@
-import type {
-  RiotAccountResponse,
-  RiotMatchHistoryResponse,
-  RiotMatchInfoResponse,
-  RiotMatchTimelineResponse,
-} from "~/types/riot";
-
 const API_KEY = process.env.RIOT_API_KEY;
 
 if (!API_KEY) {

--- a/src/lib/riot.ts
+++ b/src/lib/riot.ts
@@ -26,7 +26,7 @@ const BASE_URL = "https://americas.api.riotgames.com";
 export async function fetchAccount(
   gameName: string,
   tagLine: string,
-): Promise<RiotAccountResponse> {
+): Promise<Response> {
   const url = `${BASE_URL}/riot/account/v1/accounts/by-riot-id/${gameName}/${tagLine}`;
 
   const res = await fetch(url, {
@@ -35,11 +35,7 @@ export async function fetchAccount(
     },
   });
 
-  if (!res.ok) {
-    throw new Error(`Request failed with ${res.status}: ${await res.text()}`);
-  }
-  const data = (await res.json()) as RiotAccountResponse;
-  return data;
+  return res;
 }
 
 /**
@@ -54,7 +50,7 @@ export async function fetchAccount(
 export async function fetchMatchHistory(
   puuid: string,
   searchParams: URLSearchParams,
-): Promise<RiotMatchHistoryResponse> {
+): Promise<Response> {
   const params = new URLSearchParams();
   params.append("api_key", riotApiKey);
 
@@ -76,12 +72,7 @@ export async function fetchMatchHistory(
   const url = `${BASE_URL}/lol/match/v5/matches/by-puuid/${puuid}/ids?${params.toString()}`;
 
   const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}: ${await res.text()}`);
-  }
-
-  const matchIds = (await res.json()) as RiotMatchHistoryResponse;
-  return matchIds;
+  return res;
 }
 
 /**
@@ -94,16 +85,11 @@ export async function fetchMatchHistory(
  */
 export async function fetchMatchInfo(
   matchId: string,
-): Promise<RiotMatchInfoResponse> {
+): Promise<Response> {
   const url = `${BASE_URL}/lol/match/v5/matches/${matchId}?api_key=${riotApiKey}`;
 
   const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}: ${await res.text()}`);
-  }
-
-  const matchInfo = (await res.json()) as RiotMatchInfoResponse;
-  return matchInfo;
+  return res;
 }
 
 /**
@@ -116,14 +102,9 @@ export async function fetchMatchInfo(
  */
 export async function fetchMatchTimeline(
   matchId: string,
-): Promise<RiotMatchTimelineResponse> {
+): Promise<Response> {
   const url = `${BASE_URL}/lol/match/v5/matches/${matchId}/timeline?api_key=${riotApiKey}`;
 
   const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`HTTP ${res.status}: ${await res.text()}`);
-  }
-
-  const timeline = (await res.json()) as RiotMatchTimelineResponse;
-  return timeline;
+  return res;
 }


### PR DESCRIPTION
- Changed route to return raw response from riot
- Edited test to expect different format
- Removed static api key values

Raw response from Riot helps with debugging if there is ever an error, from the previous state, a generic error status 500 {Failed to fetch [data type]} is returned for whatever error may occur. 

Now we can see raw response with error details such as:
{
  "status": {
    "status_code": 404,
    "message": "Data not found - No results found for player with riot id c9loki#kr1"
  }
}